### PR TITLE
Fix using GTest if it is found through find_package.

### DIFF
--- a/externals/libfptu/src/erthink/cmake/testing.cmake
+++ b/externals/libfptu/src/erthink/cmake/testing.cmake
@@ -238,13 +238,15 @@ if(BUILD_TESTING)
       endif()
 
       set(GTEST_BOTH_LIBRARIES gtest gtest_main)
+      add_library(GTest::GTest ALIAS gtest)
+      add_library(GTest::Main ALIAS gtest_main)
       set(GTEST_FOUND TRUE)
     endif()
   endif()
 
   if(GTEST_FOUND)
     enable_testing()
-    set(UT_LIBRARIES ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    set(UT_LIBRARIES GTest::Main GTest::GTest Threads::Threads)
     if(MEMORYCHECK_COMMAND OR CMAKE_MEMORYCHECK_COMMAND)
       add_custom_target(test_memcheck
         COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --test-action memcheck


### PR DESCRIPTION
Hi,

This PR fixes the following issue:

At the begining of execution of testing.cmake, if GTest is being found by the cmake command ```find_package``` then the cmake variable _GTEST_BOTH_LIBRARIES_ gets assigned with a full path to gtest libraries (**not CMake targets**). As a consequence, in this case (in contrast to the case when GTest is downloaded and included to the build tree) this variable doesn't carry us any information about location of GTest's header files => the following build is failed due to inability to find GTests headers.